### PR TITLE
Fix __propagate_dump_mode__ for List field with nested model

### DIFF
--- a/marshmallow_objects/models.py
+++ b/marshmallow_objects/models.py
@@ -156,6 +156,8 @@ class Model(with_metaclass(ModelMeta)):
     def __propagate_dump_mode__(self, value):
         self.__dump_mode__ = value
         for name, field in self.__schema__.fields.items():
+            if isinstance(field, fields.List):
+                field = field.inner
             if isinstance(field, fields.Nested):
                 nested = getattr(self, name, None)
                 if nested is not None and nested != marshmallow.missing:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -540,6 +540,7 @@ class MissingCompany(marshmallow.Model):
     owner = marshmallow.NestedModel(MissingPerson)
     hr = marshmallow.NestedModel(MissingPerson, allow_none=True)
     workers = marshmallow.NestedModel(MissingPerson, many=True, allow_none=True)
+    assets = marshmallow.fields.List(marshmallow.NestedModel(MissingPerson))
 
 
 class TestMissingFields(unittest.TestCase):
@@ -558,6 +559,11 @@ class TestMissingFields(unittest.TestCase):
         obj = MissingCompany(owner={"name": "John Doe"}, workers=[{"name": "Bob"}])
         self.assertEqual(1, len(obj.workers))
         self.assertEqual({"owner": {"name": "John Doe"}, "workers": [{"name": "Bob"}]}, obj.dump())
+
+    def test_list_field_nested(self):
+        obj = MissingCompany.load({"owner": {"name": "John Doe"}, "assets": [{"name": "MissingAsset"}]})
+        self.assertEqual(1, len(obj.assets))
+        self.assertEqual({"owner": {"name": "John Doe"}, "assets": [{"name": "MissingAsset"}]}, obj.dump())
 
 
 class SelfNested(marshmallow.Model):


### PR DESCRIPTION
Missing fields were not omitted for nested model inside `marshmallow.fields.List` field:

```python
from marshmallow import fields
from marshmallow_objects import Model, NestedModel

class Person(Model):
    name = fields.String()
    age = fields.Integer()

class Company(Model):
    name = fields.String()
    owner = NestedModel(Person, allow_none=True)
    workers = fields.List(NestedModel(Person), default=[])

Company.load({'name': 'ACME', 'workers': [{'name': 'Bob'}]}).dump()
```
was returning missing `age` field:

```python
{'name': 'ACME', 'workers': [{'age': None, 'name': 'Bob'}]}
```

This PR fixes that problem.