### PR TITLE
Fix overriding of schema class

### DIFF
--- a/marshmallow_objects/models.py
+++ b/marshmallow_objects/models.py
@@ -50,7 +50,7 @@ class ModelMeta(type):
         parent_schemas = []
         if parents:
             for parent in parents:
-                if issubclass(parent, Model):
+                if issubclass(parent, Model) and parent != Model:
                     parent_schemas.append(parent.__schema_class__)
         parent_schemas = parent_schemas or [cls.__schema_class__ or marshmallow.Schema]
         schema_class = type(name + "Schema", tuple(parent_schemas), schema_fields)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -55,6 +55,15 @@ class MultiInheritance(A, B, C):
     pass
 
 
+class CustomSchema(marshmallow.Schema):
+    def custom_method(self):
+        pass
+
+
+class D(marshmallow.Model):
+    __schema_class__ = CustomSchema
+
+
 def serialize_context_field(obj, context=None):
     return obj.test_field == context["value"]
 
@@ -112,6 +121,9 @@ class TestModelMeta(unittest.TestCase):
         self.assertEqual(
             id(MultiInheritance.handle_error), id(MultiInheritance.__schema_class__.handle_error),
         )
+
+    def test_schema_class_override(self):
+        self.assertTrue(issubclass(D.__schema_class__, CustomSchema), D.__schema_class__.__bases__)
 
 
 class TestModel(unittest.TestCase):


### PR DESCRIPTION
This pull request enables developers to override default Schema class for a model.

It was not possible, because every user model has `Model` as a parent with its own `__schema_class__` and `issubclass(parent, Model)` is `True`, when `parent` is `Model`.

So excluding `Model` itself makes `MetaModel` to pick up `__schema_class__` from the user model, if it is specified.